### PR TITLE
Upgrading nightmare from v2.1 to v2.4.

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "",
   "main": "index.js",
   "dependencies": {
-    "nightmare": "^2.1.4"
+    "nightmare": "^2.4.1"
   },
   "devDependencies": {
     "chai": "^3.3.0",

--- a/test/mocha.opts
+++ b/test/mocha.opts
@@ -1,2 +1,1 @@
---timeout 20s
---require co-mocha
+--timeout 30s


### PR DESCRIPTION
## changes
- Upgrading nightmare from v2.1 to v2.4
- modifying `mocha.opts`
  - removing `require co-mocha`
  - extending timeout from 20s to 30s
